### PR TITLE
Introduce OAuth response and exception

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit colors="true" bootstrap="./tests/bootstrap.php">
     <testsuites>
-        <testsuite name="Widop Twitter Test Suite">
+        <testsuite name="Widop Twitter OAuth Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Widop/Twitter/OAuth/OAuthException.php
+++ b/src/Widop/Twitter/OAuth/OAuthException.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Wid'op package.
+ *
+ * (c) Wid'op <contact@widop.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Widop\Twitter\OAuth;
+
+/**
+ * OAuth exception.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class OAuthException extends \Exception
+{
+    /** @var \Widop\Twitter\OAuth\OAuthResponse */
+    private $response;
+
+    /**
+     * Creates an OAuth exception.
+     *
+     * @param string                             $message  The message.
+     * @param \Widop\Twitter\OAuth\OAuthResponse $response The response.
+     */
+    public function __construct($message, OAuthResponse $response)
+    {
+        parent::__construct($message, null, null);
+
+        $this->response = $response;
+    }
+
+    /**
+     * Gets the response.
+     *
+     * @return \Widop\Twitter\OAuth\OAuthResponse The response.
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Widop/Twitter/OAuth/OAuthRequest.php
+++ b/src/Widop/Twitter/OAuth/OAuthRequest.php
@@ -51,6 +51,9 @@ class OAuthRequest
     /** @var array */
     private $fileParameters;
 
+    /** @var string */
+    private $responseFormat;
+
     /**
      * Creates an OAuth request.
      */
@@ -62,6 +65,8 @@ class OAuthRequest
         $this->getParameters = array();
         $this->postParameters = array();
         $this->fileParameters = array();
+
+        $this->setResponseFormat(OAuthResponse::FORMAT_JSON);
     }
 
     /**
@@ -699,6 +704,26 @@ class OAuthRequest
         }
 
         unset($this->fileParameters[$name]);
+    }
+
+    /**
+     * Gets the response format.
+     *
+     * @return string The response format.
+     */
+    public function getResponseFormat()
+    {
+        return $this->responseFormat;
+    }
+
+    /**
+     * Sets the response format.
+     *
+     * @param string $responseFormat The response format.
+     */
+    public function setResponseFormat($responseFormat)
+    {
+        $this->responseFormat = $responseFormat;
     }
 
     /**

--- a/src/Widop/Twitter/OAuth/OAuthResponse.php
+++ b/src/Widop/Twitter/OAuth/OAuthResponse.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Wid'op package.
+ *
+ * (c) Wid'op <contact@widop.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Widop\Twitter\OAuth;
+
+use Widop\HttpAdapter\HttpResponse;
+
+/**
+ * OAuth response.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class OAuthResponse
+{
+    /** @const string The json format. */
+    const FORMAT_JSON = 'json';
+
+    /** @const string The str format. */
+    const FORMAT_STR = 'str';
+
+    /** @var \Widop\HttpAdapter\HttpResponse */
+    private $httpResponse;
+
+    /** @var string */
+    private $format;
+
+    /** @var array */
+    private $data;
+
+    /**
+     * Creates an OAuth response.
+     *
+     * @param \Widop\HttpAdapter\HttpResponse $httpResponse The http response.
+     *
+     * @throws \InvalidArgumentException If the format is not supported.
+     */
+    public function __construct(HttpResponse $httpResponse, $format = self::FORMAT_JSON)
+    {
+        $this->httpResponse = $httpResponse;
+        $this->format = $format;
+
+        if ($format === self::FORMAT_JSON) {
+            $this->data = json_decode($httpResponse->getBody(), true);
+        } else if ($format === self::FORMAT_STR) {
+            parse_str($httpResponse->getBody(), $this->data);
+        } else {
+            throw new \InvalidArgumentException(sprintf('The OAuth response format "%s" is not supported.', $format));
+        }
+    }
+
+    /**
+     * Gets the http response.
+     *
+     * @return \Widop\HttpAdapter\HttpResponse The http response.
+     */
+    public function getHttpResponse()
+    {
+        return $this->httpResponse;
+    }
+
+    /**
+     * Gets the format.
+     *
+     * @return string The format.
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * Gets the rate limit limit.
+     *
+     * @return string The rate limit limit.
+     */
+    public function getRateLimitLimit()
+    {
+        return $this->httpResponse->getHeader('X-Rate-Limit-Limit');
+    }
+
+    /**
+     * Gets the rate limit remaining.
+     *
+     * @return string The rate limit remaining.
+     */
+    public function getRateLimitRemaining()
+    {
+        return $this->httpResponse->getHeader('X-Rate-Limit-Remaining');
+    }
+
+    /**
+     * Gets the rate limit reset.
+     *
+     * @return string The rate limit reset.
+     */
+    public function getRateLimitReset()
+    {
+        return $this->httpResponse->getHeader('X-Rate-Limit-Reset');
+    }
+
+    /**
+     * Checks if there is data or a specific data.
+     *
+     * @param string $name The data name.
+     *
+     * @return boolean TRUE if there is data else FALSE.
+     */
+    public function hasData($name = null)
+    {
+        if ($name !== null) {
+            return is_array($this->data) && isset($this->data[$name]);
+        }
+
+        return !empty($this->data);
+    }
+
+    /**
+     * Gets the data or a specific data.
+     *
+     * @param null|string The data name.
+     *
+     * @return mixed The result.
+     */
+    public function getData($name = null)
+    {
+        if ($name !== null) {
+            return $this->hasData($name) ? $this->data[$name] : null;
+        }
+
+        return $this->data;
+    }
+
+    /**
+     * Checks if the response is valid.
+     *
+     * @return boolean TRUE if the response is valid else FALSE.
+     */
+    public function isValid()
+    {
+        return !$this->hasData('errors');
+    }
+}

--- a/tests/Widop/Tests/Twitter/OAuth/OAuthExceptionTest.php
+++ b/tests/Widop/Tests/Twitter/OAuth/OAuthExceptionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Wid'op package.
+ *
+ * (c) Wid'op <contact@widop.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Widop\Tests\Twitter\OAuth;
+
+use Widop\Twitter\OAuth\OAuthException;
+
+/**
+ * OAuth exception test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class OAuthExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Widop\Twitter\OAuth\OAuthException */
+    protected $exception;
+
+    /** @var string */
+    protected $message;
+
+    /** @var \Widop\Twitter\OAuth\OAuthResponse */
+    protected $response;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->response = $this->getMockBuilder('Widop\Twitter\OAuth\OAuthResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->message = 'foo';
+        $this->exception = new OAuthException($this->message, $this->response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->response);
+        unset($this->message);
+        unset($this->exception);
+    }
+
+    public function testMessage()
+    {
+        $this->assertSame($this->message, $this->exception->getMessage());
+    }
+
+    public function testResponse()
+    {
+        $this->assertSame($this->response, $this->exception->getResponse());
+    }
+}

--- a/tests/Widop/Tests/Twitter/OAuth/OAuthRequestTest.php
+++ b/tests/Widop/Tests/Twitter/OAuth/OAuthRequestTest.php
@@ -12,6 +12,7 @@
 namespace Widop\Tests\Twitter\OAuth;
 
 use Widop\Twitter\OAuth\OAuthRequest;
+use Widop\Twitter\OAuth\OAuthResponse;
 
 /**
  * OAuth request test.
@@ -393,6 +394,18 @@ class OAuthRequestTest extends \PHPUnit_Framework_TestCase
     public function testRemoveFileParameterWithInvalidName()
     {
         $this->request->removeFileParameter('foo');
+    }
+
+    public function testDefaultResponseFormat()
+    {
+        $this->assertSame(OAuthResponse::FORMAT_JSON, $this->request->getResponseFormat());
+    }
+
+    public function testResponseFormat()
+    {
+        $this->request->setResponseFormat(OAuthResponse::FORMAT_STR);
+
+        $this->assertSame(OAuthResponse::FORMAT_STR, $this->request->getResponseFormat());
     }
 
     public function testSignatureUrlWithoutPathParameters()

--- a/tests/Widop/Tests/Twitter/OAuth/OAuthResponseTest.php
+++ b/tests/Widop/Tests/Twitter/OAuth/OAuthResponseTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Wid'op package.
+ *
+ * (c) Wid'op <contact@widop.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Widop\Tests\Twitter\OAuth;
+
+use Widop\Twitter\OAuth\OAuthResponse;
+
+/**
+ * OAuth response test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class OAuthResponseTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Widop\Twitter\OAuth\OAuthResponse */
+    protected $oauthResponse;
+
+    /** @var \Widop\HttpAdapter\HttpResponse */
+    protected $httpResponse;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->httpResponse = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->httpResponse
+            ->expects($this->any())
+            ->method('getHeader')
+            ->will($this->returnValueMap(array(
+                array('X-Rate-Limit-Limit', 'limit'),
+                array('X-Rate-Limit-Remaining', 'remaining'),
+                array('X-Rate-Limit-Reset', 'reset'),
+            )));
+
+        $this->oauthResponse = new OAuthResponse($this->httpResponse);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->response);
+    }
+
+    public function testHttpResponse()
+    {
+        $this->assertSame($this->httpResponse, $this->oauthResponse->getHttpResponse());
+    }
+
+    public function testRateLimitLimit()
+    {
+        $this->assertSame('limit', $this->oauthResponse->getRateLimitLimit());
+    }
+
+    public function testRateLimitRemaining()
+    {
+        $this->assertSame('remaining', $this->oauthResponse->getRateLimitRemaining());
+    }
+
+    public function testRateLimitReset()
+    {
+        $this->assertSame('reset', $this->oauthResponse->getRateLimitReset());
+    }
+
+    public function testFormat()
+    {
+        $this->assertSame(OAuthResponse::FORMAT_JSON, $this->oauthResponse->getFormat());
+    }
+
+    public function testDataWithoutResult()
+    {
+        $this->httpResponse
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue('{}'));
+
+        $this->oauthResponse = new OAuthResponse($this->httpResponse);
+
+        $this->assertFalse($this->oauthResponse->hasData());
+        $this->assertEmpty($this->oauthResponse->getData());
+
+        $this->assertFalse($this->oauthResponse->hasData('foo'));
+        $this->assertNull($this->oauthResponse->getData('foo'));
+    }
+
+    public function testDataWithJsonFormat()
+    {
+        $this->httpResponse
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue('{"foo":"bar"}'));
+
+        $this->oauthResponse = new OAuthResponse($this->httpResponse);
+
+        $this->assertTrue($this->oauthResponse->hasData());
+        $this->assertSame(array('foo' => 'bar'), $this->oauthResponse->getData());
+
+        $this->assertTrue($this->oauthResponse->hasData('foo'));
+        $this->assertSame('bar', $this->oauthResponse->getData('foo'));
+    }
+
+    public function testDataWithStrFormat()
+    {
+        $this->httpResponse
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue('foo=bar'));
+
+        $this->oauthResponse = new OAuthResponse($this->httpResponse, OAuthResponse::FORMAT_STR);
+
+        $this->assertTrue($this->oauthResponse->hasData());
+        $this->assertSame(array('foo' => 'bar'), $this->oauthResponse->getData());
+
+        $this->assertTrue($this->oauthResponse->hasData('foo'));
+        $this->assertSame('bar', $this->oauthResponse->getData('foo'));
+    }
+
+    public function testIsValidWithValidResponse()
+    {
+        $this->httpResponse
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue('{"foo":"bar"}'));
+
+        $this->oauthResponse = new OAuthResponse($this->httpResponse);
+
+        $this->assertTrue($this->oauthResponse->isValid());
+    }
+
+    public function testIsValidWithInvalidResponse()
+    {
+        $this->httpResponse
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue('{"errors":"foo"}'));
+
+        $this->oauthResponse = new OAuthResponse($this->httpResponse);
+
+        $this->assertFalse($this->oauthResponse->isValid());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The OAuth response format "foo" is not supported.
+     */
+    public function testInvalidFormat()
+    {
+        new OAuthResponse($this->httpResponse, 'foo');
+    }
+}

--- a/tests/Widop/Tests/Twitter/OAuth/OAuthTest.php
+++ b/tests/Widop/Tests/Twitter/OAuth/OAuthTest.php
@@ -13,6 +13,7 @@ namespace Widop\Tests\Twitter\OAuth;
 
 use Widop\Twitter\OAuth\OAuth;
 use Widop\Twitter\OAuth\OAuthRequest;
+use Widop\Twitter\OAuth\OAuthResponse;
 use Widop\Twitter\OAuth\Token\OAuthToken;
 
 /**
@@ -161,7 +162,10 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRequestTokenWithoutCallback()
     {
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
@@ -197,7 +201,10 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRequestTokenWithCallback()
     {
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
@@ -267,7 +274,10 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAccessToken()
     {
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
@@ -302,16 +312,19 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Widop\Twitter\OAuth\OAuthException
      * @expectedExceptionMessage An error occured when creating the bearer token.
      */
-    public function testGetBearerTokenWithBadAdapterReturn()
+    public function testGetBearerTokenWithInvalidResult()
     {
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
-            ->will($this->returnValue('foo'));
+            ->will($this->returnValue('{"foo":"bar"}'));
 
         $this->httpAdapter
             ->expects($this->once())
@@ -328,7 +341,10 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBearerToken()
     {
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
@@ -361,7 +377,10 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
             ->method('getValue')
             ->will($this->returnValue('token'));
 
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
@@ -381,7 +400,7 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Widop\Twitter\OAuth\OAuthException
      * @expectedExceptionMessage An error occured when invalidating the bearer token.
      */
     public function testInvalidateBearerTokenWithInvalidResponse()
@@ -391,15 +410,18 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $bearerToken
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getValue')
             ->will($this->returnValue('token'));
 
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
-            ->will($this->returnValue('foo'));
+            ->will($this->returnValue('{"foo":"bar"}'));
 
         $this->httpAdapter
             ->expects($this->once())
@@ -432,11 +454,19 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
             ->method('getHeaders')
             ->will($this->returnValue(array('header' => 'foo')));
 
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $request
+            ->expects($this->once())
+            ->method('getResponseFormat')
+            ->will($this->returnValue(OAuthResponse::FORMAT_JSON));
+
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
-            ->will($this->returnValue('foo'));
+            ->will($this->returnValue('{"foo":"bar"}'));
 
         $this->httpAdapter
             ->expects($this->once())
@@ -444,7 +474,7 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
             ->with($this->identicalTo('url'), $this->identicalTo(array('header' => 'foo')))
             ->will($this->returnValue($response));
 
-        $this->assertSame('foo', $this->oauth->sendRequest($request));
+        $this->assertSame(array('foo' => 'bar'), $this->oauth->sendRequest($request)->getData());
     }
 
     public function testSendRequestWithPostRequest()
@@ -475,11 +505,19 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
             ->method('getFileParameters')
             ->will($this->returnValue(array('file' => 'baz')));
 
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $request
+            ->expects($this->once())
+            ->method('getResponseFormat')
+            ->will($this->returnValue(OAuthResponse::FORMAT_JSON));
+
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')
-            ->will($this->returnValue('foo'));
+            ->will($this->returnValue('{"foo":"bar"}'));
 
         $this->httpAdapter
             ->expects($this->once())
@@ -492,7 +530,7 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($response));
 
-        $this->assertSame('foo', $this->oauth->sendRequest($request));
+        $this->assertSame(array('foo' => 'bar'), $this->oauth->sendRequest($request)->getData());
     }
 
     /**
@@ -511,12 +549,60 @@ class OAuthTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage An error occured when creating the OAuth token. (foo)
+     * @expectedException \Widop\Twitter\OAuth\OAuthException
+     * @expectedExceptionMessage The http response is not valid.
+     */
+    public function testSendRequestWithErroredRequest()
+    {
+        $request = $this->getMock('Widop\Twitter\OAuth\OAuthRequest');
+        $request
+            ->expects($this->once())
+            ->method('getMethod')
+            ->will($this->returnValue(OAuthRequest::METHOD_GET));
+
+        $request
+            ->expects($this->once())
+            ->method('getUrl')
+            ->will($this->returnValue('url'));
+
+        $request
+            ->expects($this->once())
+            ->method('getHeaders')
+            ->will($this->returnValue(array('header' => 'foo')));
+
+        $request
+            ->expects($this->once())
+            ->method('getResponseFormat')
+            ->will($this->returnValue(OAuthResponse::FORMAT_JSON));
+
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue('{"errors":"foo"}'));
+
+        $this->httpAdapter
+            ->expects($this->once())
+            ->method('getContent')
+            ->with($this->identicalTo('url'), $this->identicalTo(array('header' => 'foo')))
+            ->will($this->returnValue($response));
+
+        $this->oauth->sendRequest($request);
+    }
+
+    /**
+     * @expectedException \Widop\Twitter\OAuth\OAuthException
+     * @expectedExceptionMessage An error occured when creating the OAuth token.
      */
     public function testGetRequestTokenError()
     {
-        $response = $this->getMock('Widop\HttpAdapter\Response');
+        $response = $this->getMockBuilder('Widop\HttpAdapter\HttpResponse')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $response
             ->expects($this->once())
             ->method('getBody')


### PR DESCRIPTION
This PR is the second step in order to fix widop/twitter-rest#33. Now, the `sendRequest` method returns a `OAuthResponse` which wraps the original http response and some convenient method in order to easily access usefull informations.

Additionally, it introduces the `OAuthException` which wraps an `OAuthResponse` allowing to have a more complete access to the informations related to the error.
